### PR TITLE
Upgrade mwax_update_subfile_header utililty

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 A collection of handy scripts, tools and utilities for users of the MWAX correlator.
 
 ## Contents
+
 * utils - contains handy utilties.
- * mwax_update_subfile_header - a utility to rewrite the subfile PSRDADA header with a new one provided with a text file.
-  * Depends on the PSRDADA library
+  * mwax_update_subfile_header - a utility to rewrite the subfile PSRDADA header with a new one provided with a text file.
 * reinterleave_subfile - a utility to undo the block ordering of one or more subfiles and generate a raw output stream
 

--- a/README.md
+++ b/README.md
@@ -4,5 +4,6 @@ A collection of handy scripts, tools and utilities for users of the MWAX correla
 ## Contents
 * utils - contains handy utilties.
  * mwax_update_subfile_header - a utility to rewrite the subfile PSRDADA header with a new one provided with a text file.
- * reinterleave_subfile - a utility to undo the block ordering of one or more subfiles and generate a raw output stream
+  * Depends on the PSRDADA library
+* reinterleave_subfile - a utility to undo the block ordering of one or more subfiles and generate a raw output stream
 

--- a/utils/mwax_update_subfile_header/Makefile
+++ b/utils/mwax_update_subfile_header/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
 LDLIBS = -lpsrdada
-CFLAGS = -Wall -Wextra -O2
+CFLAGS = -Wall -Wextra -Ofast
 
 mwax_update_subfile_header: mwax_update_subfile_header.o

--- a/utils/mwax_update_subfile_header/Makefile
+++ b/utils/mwax_update_subfile_header/Makefile
@@ -1,0 +1,5 @@
+CC = gcc
+LDLIBS = -lpsrdada
+CFLAGS = -Wall -Wextra -O2
+
+mwax_update_subfile_header: mwax_update_subfile_header.o

--- a/utils/mwax_update_subfile_header/README.md
+++ b/utils/mwax_update_subfile_header/README.md
@@ -1,0 +1,11 @@
+# `mwax_update_subfile_header`
+
+## Dependencies
+
+- [PSRDADA](http://psrdada.sourceforge.net/index.shtml)
+
+## Compiling
+
+```
+make
+```

--- a/utils/mwax_update_subfile_header/mwax_update_subfile_header.c
+++ b/utils/mwax_update_subfile_header/mwax_update_subfile_header.c
@@ -98,7 +98,7 @@ void usage(FILE *f, char **argv)
     fprintf(f, "usage: %s [-h] [-s KEY=VAL [-s ...]] [-d KEY [-d ...]] SUBFILE [SUBFILE ...]\n", argv[0]);
     fprintf(f, "\t-d KEY        Deletes KEY from header.\n");
     fprintf(f, "\t-h            Prints this help and exits.\n");
-    fprintf(f, "\t-s KEY=VAL    Sets the value of KEY to VAL. If KEY does not exist, it is created.\n");
+    fprintf(f, "\t-s KEY=VAL    Sets the value of VAL to KEY. If KEY does not exist, it is created.\n");
     fprintf(f, "If no -d or -s is given, then the subfile headers are printed out to stdout\n");
 }
 

--- a/utils/mwax_update_subfile_header/mwax_update_subfile_header.c
+++ b/utils/mwax_update_subfile_header/mwax_update_subfile_header.c
@@ -1,20 +1,16 @@
 // 
-// *Very* basic utility to replace an existing subfile header with a header based on a supplied text file.
+// Basic utility to replace an existing subfile header with a header based on a supplied text file.
 //
 // To compile: 
-//   gcc -Wall -Ofast mwax_update_subfile_header.c -oupdate_mwax_subfile_header -lrt
+//   gcc -Wall -Ofast mwax_update_subfile_header.c -o mwax_update_subfile_header -lpsrdada
 //
 // Usage:
-//   mwax_update_subfile_header HEADERFILE SUBFILE
+//   mwax_update_subfile_header [-h] [-s KEY=VAL [-s ...]] [-d KEY [-d ...]] SUBFILE [SUBFILE ...]
 //
-// Where:
-//   HEADERFILE is an ASCII text file containing the PSRDADA header you want for the SUBFILE.
+//   Run `mwax_update_subfile_header -h` for more detailed usage information.
 //
 // See the following link for a description of an MWAX Subfile PSRDADA header: https://wiki.mwatelescope.org/display/MP/MWAX+PSRDADA+header
 // 
-// TODO: make more user friendly with standard command line arg parsing and --help for usage info
-// TODO: better error handling
-// TODO: provide a method (or another tool) which will just take a subfile and correlator params and just update those. This will be useful for folks using the MWAX Offline correlator especially!
 //
 
 #include <stdio.h>

--- a/utils/mwax_update_subfile_header/mwax_update_subfile_header.c
+++ b/utils/mwax_update_subfile_header/mwax_update_subfile_header.c
@@ -149,7 +149,7 @@ int main(int argc, char **argv)
             continue;
         }
 
-        // If we got to here, then there are at least come modifications to be made
+        // If we got to here, then there are at least some modifications to be made
         while (kv != NULL)
         {
             switch (kv->instruction)

--- a/utils/mwax_update_subfile_header/mwax_update_subfile_header.c
+++ b/utils/mwax_update_subfile_header/mwax_update_subfile_header.c
@@ -30,6 +30,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <time.h>
+#include <ascii_header.h> // Supplied by PSRDADA
 
 #define FALSE 0
 #define TRUE !(FALSE)
@@ -47,6 +48,26 @@
 #define UINT64 unsigned long long int
 
 #define HEADER_LEN 4096
+
+#define MAX_KV_SIZE 256
+
+// A basic linked list struct
+struct key_val
+{
+    char key[MAX_KV_SIZE];
+    char val[MAX_KV_SIZE];
+    struct key_val *next;
+};
+
+void usage(FILE *f, char **argv)
+{
+    fprintf(f, "Modifies subfile headers in-place\n"
+    fprintf(f, "usage: %s [-s KEY=VAL [-s ...]] [-d KEY] SUBFILE [SUBFILE ...]\n", argv[0]);
+    fprintf(f, "\t-s KEY=VAL    Sets the value of KEY to VAL. If KEY does not exist, it is created.\n");
+    fprintf(f, "\t-d KEY        Deletes KEY from header\n");
+}
+
+int parse_cmdline(int argc, char **argv, struct key_val *kv);
 
 int main(int argc, char **argv)
 {
@@ -93,4 +114,14 @@ int main(int argc, char **argv)
     printf( "Header updated successfully\n" );
 
     exit(0);
+}
+
+/**
+ * Parse the command line
+ * @param argc Same as main()
+ * @param argv Same as main()
+ * @return A pointer to a newly constructed linked list
+ */
+struct key_val *parse_cmdline(int argc, char **argv);
+{
 }

--- a/utils/mwax_update_subfile_header/mwax_update_subfile_header.c
+++ b/utils/mwax_update_subfile_header/mwax_update_subfile_header.c
@@ -62,31 +62,39 @@ struct keyval
     struct keyval *next;
 };
 
-int append_keyval(struct keyval *kv, const char *key, const char *val, int instruction)
+int append_keyval(struct keyval **kv, const char *key, const char *val, int instruction)
 {
-    if (kv == NULL) // If kv is an empty list...
+    struct keyval *new_kv;
+
+    if (*kv == NULL) // If kv is an empty list...
     {
-        kv = (struct keyval *)malloc(sizeof(struct keyval));
+        *kv = (struct keyval *)malloc(sizeof(struct keyval));
+        new_kv = *kv;
     }
     else
     {
+        new_kv = *kv;
+
         // Move to the end of the list
-        while (kv->next != NULL)
-            kv = kv->next;
+        while (new_kv->next != NULL)
+            new_kv = new_kv->next;
 
         // Create a new node and move to it
-        kv->next = (struct keyval *)malloc(sizeof(struct keyval));
-        kv = kv->next;
+        new_kv->next = (struct keyval *)malloc(sizeof(struct keyval));
+        new_kv = new_kv->next;
     }
 
     // Update the values
     if (key != NULL)
-        snprintf(kv->key, MAX_KV_SIZE, "%s", key);
+        snprintf(new_kv->key, MAX_KV_SIZE, "%s", key);
 
     if (val != NULL)
-        snprintf(kv->val, MAX_KV_SIZE, "%s", val);
+        snprintf(new_kv->val, MAX_KV_SIZE, "%s", val);
 
-    kv->instruction = instruction;
+    new_kv->instruction = instruction;
+    new_kv->next = NULL;
+
+    return EXIT_SUCCESS;
 }
 
 void usage(FILE *f, char **argv)
@@ -104,20 +112,24 @@ int main(int argc, char **argv)
 {
     // Parse the command line
     int first_filename_idx;
-    struct keyval *kv = parse_cmdline(argc, argv, &first_filename_idx);
+    struct keyval *first_kv = parse_cmdline(argc, argv, &first_filename_idx);
+    struct keyval *kv;
+
+    // Set up variables for handling I/O
+    int file_descr;
+
+    int input_read;
+    int input_write;
+
+    char header_buffer[HEADER_LEN];
 
     // Loop over the remaining arguments, open the files, and view/modify their headers
     int i;
     for (i = first_filename_idx; i < argc; i++)
     {
-        int file_descr;
+        printf("Opening %s...\n", argv[i]);
 
-        int input_read;
-        int input_write;
-
-        char header_buffer[HEADER_LEN];
-
-        file_descr = open( argv[i], O_RDONLY );
+        file_descr = open( argv[i], O_RDWR );
         if (file_descr < 0)
         {
             printf( "ERROR: Error opening header file: %s\n", argv[i] );
@@ -133,6 +145,7 @@ int main(int argc, char **argv)
 
         // If there are no -d's or -s's, then kv will be NULL.
         // In this case, just read in the headers and print them to stdout
+        kv = first_kv;
         if (kv == NULL)
         {
             printf("%s:\n%s\n", argv[i], header_buffer);
@@ -140,26 +153,44 @@ int main(int argc, char **argv)
             continue;
         }
 
-        close ( file_descr );
+        // If we got to here, then there are at least come modifications to be made
+        while (kv != NULL)
+        {
+            switch (kv->instruction)
+            {
+                case MODIFY_KV:
+                    if (ascii_header_set(header_buffer, kv->key, "%s", kv->val) == -1)
+                    {
+                        fprintf(stderr, "WARNING: Could not modify/create %s=%s\n", kv->key, kv->val);
+                    }
+                    break;
+                case DELETE_KV:
+                    if (ascii_header_del(header_buffer, kv->key) == -1)
+                    {
+                        fprintf(stderr, "WARNING: Could not delete keyword %s\n", kv->key);
+                    }
+                    break;
+                default:
+                    fprintf(stderr, "WARNING: Unrecognised instruction code (%d)\n", kv->instruction);
+            }
 
-        file_descr = open( argv[2], O_WRONLY );
-        if (file_descr < 0) {
-            printf( "Error opening destination file:%s\n", argv[2] );
-            exit(0);
+            kv = kv->next;
         }
 
-        input_write = write ( file_descr, header_buffer, HEADER_LEN );
-        if (input_write != HEADER_LEN) {
-            printf( "Write to %s failed.  Returned a value of %d.\n", argv[2], input_write );
-            exit(0);
+        // Now that the header buffer has been suitably altered, write it back to the beginning of the file
+        lseek(file_descr, 0, SEEK_SET);
+        input_write = write(file_descr, header_buffer, HEADER_LEN);
+        if (input_write != HEADER_LEN)
+        {
+            printf("FATAL WARNING: Write to %s failed.  Returned a value of %d. "
+                    "The header may now be corrupted.\n", argv[i], input_write);
+            exit(EXIT_FAILURE);
         }
 
-        close ( file_descr );
-
-        printf( "Header updated successfully\n" );
-
-        exit(EXIT_SUCCESS);
+        close(file_descr);
     }
+
+    exit(EXIT_SUCCESS);
 }
 
 /**
@@ -182,7 +213,7 @@ struct keyval *parse_cmdline(int argc, char **argv, int *first_filename_idx)
         switch (opt)
         {
             case 'd':
-                append_keyval(kv, key, NULL, DELETE_KV);
+                append_keyval(&kv, optarg, NULL, DELETE_KV);
                 break;
             case 'h':
                 printf("Modifies subfile headers in-place\n");
@@ -198,7 +229,7 @@ struct keyval *parse_cmdline(int argc, char **argv, int *first_filename_idx)
                     usage(stderr, argv);
                     exit(EXIT_FAILURE);
                 }
-                append_keyval(kv, key, val, MODIFY_KV);
+                append_keyval(&kv, key, val, MODIFY_KV);
                 break;
             default:
                 fprintf(stderr, "ERROR: Unrecognised option '-%c'\n", opt);


### PR DESCRIPTION
Preview of usage:
```
Modifies subfile headers in-place
usage: ./mwax_update_subfile_header [-h] [-s KEY=VAL [-s ...]] [-d KEY [-d ...]] SUBFILE [SUBFILE ...]
	-d KEY        Deletes KEY from header.
	-h            Prints this help and exits.
	-s KEY=VAL    Sets the value of VAL to KEY. If KEY does not exist, it is created.
If no -d or -s is given, then the subfile headers are printed out to stdout
```